### PR TITLE
Close files, and prevent reading subsequent, nonexistant files

### DIFF
--- a/SkittleCore/FastaFiles.py
+++ b/SkittleCore/FastaFiles.py
@@ -24,8 +24,12 @@ def readFile(state):
             print "opening file ", filePath, " for ", state.specimen, state.chromosome, str(state.start)
         if not filePath:
             return None
-        rawFile = open(filePath, 'r')
-        result = rawFile.read()
+
+        result = None
+
+        with open(filePath, 'r') as rawFile:
+            result = rawFile.read()
+
         return result
 
     #        print 'Opened File'

--- a/SkittleCore/models.py
+++ b/SkittleCore/models.py
@@ -116,8 +116,6 @@ class RequestPacket(basePacket):
         self.seq = ''
         self.length = len(self.seq)
         partialSequences = []
-
-        # accumulate the chunks into self.seq
         for index, chunkStart in enumerate(range(self.start, self.start + numChunks * chunkSize, chunkSize)):
             tempState = self.copy()
             tempState.start = chunkStart

--- a/SkittleCore/models.py
+++ b/SkittleCore/models.py
@@ -115,6 +115,7 @@ class RequestPacket(basePacket):
             return
         self.seq = ''
         self.length = len(self.seq)
+        partialSequences = []
 
         # accumulate the chunks into self.seq
         for index, chunkStart in enumerate(range(self.start, self.start + numChunks * chunkSize, chunkSize)):
@@ -125,7 +126,9 @@ class RequestPacket(basePacket):
             if chunk is None:
                 break
             else:
-                self.seq += chunk
+                partialSequences.append(chunk)
+
+        self.seq = "".join(partialSequences)
 
         if self.scale >= 10:
             print "Done reading files"

--- a/SkittleCore/models.py
+++ b/SkittleCore/models.py
@@ -115,14 +115,18 @@ class RequestPacket(basePacket):
             return
         self.seq = ''
         self.length = len(self.seq)
-        partialSequences = [None] * numChunks
+
+        # accumulate the chunks into self.seq
         for index, chunkStart in enumerate(range(self.start, self.start + numChunks * chunkSize, chunkSize)):
             tempState = self.copy()
             tempState.start = chunkStart
-            partialSequences[index] = readFile(tempState)
-            if partialSequences[index] is None:
-                partialSequences[index] = ''
-        self.seq = ''.join(partialSequences)
+
+            chunk = readFile(tempState)
+            if chunk is None:
+                break
+            else:
+                self.seq += chunk
+
         if self.scale >= 10:
             print "Done reading files"
         self.length = len(self.seq)


### PR DESCRIPTION
Initially, readFastaChunks() tries to open every possible chunk it can, which can result in excessive looping. It now stops when a file is not found (no more data to be read). Also, for brevity, accumulation is done directly into `self.seq`