### PR TITLE
django's simplejson was deprecated since v1.5

### DIFF
--- a/DNAStorage/views.py
+++ b/DNAStorage/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.http import HttpResponse
-from django.utils import simplejson
+import json
 from django import forms
 from django.contrib.auth.decorators import login_required
 from itertools import chain
@@ -76,5 +76,5 @@ def Upload(request):
 
 
 def taxonomy(request):
-    json = "currentTaxonomy = " + simplejson.dumps(StorageRequestHandler.GetTreeList())
-    return HttpResponse(json, content_type="application/json")
+    json_response = "currentTaxonomy = " + json.dumps(StorageRequestHandler.GetTreeList())
+    return HttpResponse(json_response, content_type="application/json")


### PR DESCRIPTION
Also broke things on my system. Modern Django installs don't have (or reference) json implementations anymore (in favor of Python's own json lib).

Read more here:
https://code.djangoproject.com/ticket/18023