### PR TITLE
Fix recurring server errors: feedback, PhotoGallery, sequence NaN, password reset, ALLOWED_HOSTS

### DIFF
--- a/SkittleCore/Graphs/PhotoGallery.py
+++ b/SkittleCore/Graphs/PhotoGallery.py
@@ -90,7 +90,7 @@ def createSnippetEntries(repeatMap, state):
 
 
 def snippetEntriesToPixels(maxWidth, snippets, state):
-    pixels = [] if snippets else [None]  # defaults to single blank pixel
+    pixels = []
     for snippet in snippets:
         padForHorizontalLineSynchronization(state.nucleotidesPerLine(), maxWidth, pixels, snippet.start)
         pixels += arrangePixels(state, snippet, maxWidth)

--- a/SkittleCore/admin.py
+++ b/SkittleCore/admin.py
@@ -33,7 +33,7 @@ class UserChangeForm(forms.ModelForm):
 
     class Meta:
         model = SkittleUser
-        fields = ['email', 'FirstName', 'LastName', 'password', 'IsActive', 'IsAdmin']
+        fields = ['email', 'FirstName', 'LastName', 'password', 'is_active', 'IsAdmin']
 
     def clean_password(self):
         return self.initial["password"]

--- a/SkittleCore/models.py
+++ b/SkittleCore/models.py
@@ -176,12 +176,9 @@ class SkittleUser(AbstractBaseUser, PermissionsMixin):
     FirstName = models.CharField(verbose_name='First Name', max_length=255,)
     LastName = models.CharField(verbose_name='Last Name', max_length=255, null=True, blank=True,)
     IsAdmin = models.BooleanField(verbose_name='Admin Status', default=False, help_text='Designates whether this user is an Admin/On Staff or not.',)
-    IsActive = models.BooleanField(verbose_name='Active Status', default=True,)
+    is_active = models.BooleanField(verbose_name='Active Status', default=True, db_column='IsActive')
     DateJoined = models.DateTimeField(verbose_name='Date joined', default=timezone.now)
     NewUser = models.BooleanField(verbose_name='New user', default=True, help_text='Designates if this is the user\'s first visit to the site or not.')
-
-    is_staff = IsAdmin
-    is_active = IsActive
 
     objects = SkittleUserManager()
 
@@ -209,10 +206,6 @@ class SkittleUser(AbstractBaseUser, PermissionsMixin):
     def is_staff(self):
         "Is the user a member of the admin team?"
         return self.IsAdmin
-
-    @property
-    def is_active(self):
-        return self.IsActive
 
     State = models.OneToOneField(StatePacket, null=True)
 

--- a/SkittleCore/views.py
+++ b/SkittleCore/views.py
@@ -68,8 +68,14 @@ def sequence(request, genus="homo", species="sapiens", specimen="hg18", chromoso
     state = createRequestPacket(request, specimen, chromosome)
     import SequenceLogic
 
-    searchStart = int(request.GET.get('queryStart', 10000))
-    searchStop = int(request.GET.get('queryStop', 10010))
+    try:
+        searchStart = int(request.GET.get('queryStart', 10000))
+    except (ValueError, TypeError):
+        searchStart = 10000
+    try:
+        searchStop = int(request.GET.get('queryStop', 10010))
+    except (ValueError, TypeError):
+        searchStop = 10010
     seq = SequenceLogic.getSearchSequenceFromRequestPacket(state, searchStart, searchStop)
     return HttpResponse(seq)
 

--- a/SkittleTree/production_settings.py.template
+++ b/SkittleTree/production_settings.py.template
@@ -25,7 +25,8 @@ DEBUG = False
 
 # If not a subdomain, you need the www version and bare version ['www.mydomain.com', 'mydomain.com']
 # If on a subdomain, you just need the one entry ['subdomain.mydomain.com', ]
-ALLOWED_HOSTS = ['CHANGE_ME', ]
+# Clients sometimes send the FQDN form with a trailing dot ('mydomain.com.'); include those too.
+ALLOWED_HOSTS = ['CHANGE_ME', 'CHANGE_ME.', ]
 
 
 DATABASES = {

--- a/SkittleTree/views.py
+++ b/SkittleTree/views.py
@@ -43,26 +43,26 @@ def feedbackSend(request):
         contact_sender = request.POST.get('feedback_contact_sender', False)
         content = request.POST.get('feedback_content', '')
         current_view = request.POST.get('feedback_current_view', '')
-        if len(current_view) > 0:
-            subject = 'Skittle Feedback:' + feedback_type
-            message = ""
-            if sender_email:
-                message += "from: " + sender_email + "\n"
-            if contact_sender:
-                message += "requested a reply.\n"
-            if current_view:
-                message += "url: " + current_view + ' \n'
-            message += '\nMessage:\n' + content
-            receivers = ["info@newline.us", ]
-            if contact_sender and sender_email:
-                receivers.append(sender_email)
-            try:
-                send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, receivers, fail_silently=False)
-                return HttpResponse("Success")
-            except Exception as e:
-                return HttpResponse("Something went wrong: " + str(e))
-    else:
-        return HttpResponse("Something went wrong.")
+        if len(current_view) == 0:
+            return HttpResponse("Missing feedback_current_view.")
+        subject = 'Skittle Feedback:' + feedback_type
+        message = ""
+        if sender_email:
+            message += "from: " + sender_email + "\n"
+        if contact_sender:
+            message += "requested a reply.\n"
+        if current_view:
+            message += "url: " + current_view + ' \n'
+        message += '\nMessage:\n' + content
+        receivers = ["info@newline.us", ]
+        if contact_sender and sender_email:
+            receivers.append(sender_email)
+        try:
+            send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, receivers, fail_silently=False)
+            return HttpResponse("Success")
+        except Exception as e:
+            return HttpResponse("Something went wrong: " + str(e))
+    return HttpResponse("Something went wrong.")
 
 
 def google(request):


### PR DESCRIPTION
Fixes for the five recurring server-error patterns compiled from support@dnaskittle.com traces.

## Summary

**Bug 1 — `/sendFeedback` view doesn't return HttpResponse** (`SkittleTree/views.py`)
Spam bots POST with empty `feedback_current_view`, which skipped the only returns inside the POST branch; the `else` only matched non-POST requests, so the view fell through returning `None`. Flattened the branch and added an early return for the empty-view case.

**Bug 2 — PhotoGallery `TypeError: NoneType has no len()`** (`SkittleCore/Graphs/PhotoGallery.py`)
When `createSnippetEntries` returned `[]`, `snippetEntriesToPixels` seeded pixels with `[None]` and then called `padForHorizontalLineSynchronization`, whose `assert not pixels or len(pixels[-1]) == lineWidth` hit `len(None)`. Seeded with `[]` instead; pad fills it with properly-shaped blank lines.

**Bug 3 — `/sequence.fa` `int('NaN')`** (`SkittleCore/views.py`)
Frontend and bots pass `queryStart=NaN` / `queryStop=NaN`. Wrapped the `int()` calls in try/except falling back to the existing defaults (10000, 10010).

**Bug 4 — password reset `FieldError: Cannot resolve keyword 'is_active'`** (`SkittleCore/models.py`, `SkittleCore/admin.py`)
`SkittleUser` only had `IsActive` (PascalCase). The class-level alias `is_active = IsActive` was immediately shadowed by a later `@property is_active`, so Django's metaclass saw no `is_active` field and `PasswordResetForm.save()`'s `filter(email__iexact=..., is_active=True)` raised. Renamed the Python attr to `is_active` with `db_column='IsActive'` (no DB migration needed), removed the broken alias and shadowing property, updated the single admin reference.

**Bug 5 — Invalid `HTTP_HOST` with trailing dot** (`SkittleTree/production_settings.py.template`)
`dnaskittle.com.` (FQDN canonical form) isn't in `ALLOWED_HOSTS`. The actual prod setting lives outside the repo — updated the template to document the trap. Josiah will need to add `'dnaskittle.com.'` and `'www.dnaskittle.com.'` to `ALLOWED_HOSTS` in `production_settings.py` on the server.

## Test plan
- [ ] POST to `/sendFeedback` with empty `feedback_current_view` → 200, no trace.
- [ ] Browse `/browse/Homo/Sapiens/hg19/chr19/data.png?graph=p&start=1&scale=1&width=97` and `chrM` equivalent → PNG returned, no TypeError.
- [ ] GET `/browse/.../sequence.fa?queryStart=NaN&queryStop=NaN` → 200 with default-range sequence.
- [ ] `/accounts/resetpassword/` submit with a real user → reset email sent, no FieldError.
- [ ] After adding trailing-dot hosts to prod `ALLOWED_HOSTS`: `curl -H 'Host: dnaskittle.com.' https://dnaskittle.com/` → 200.
- [ ] Sanity: existing login / admin / user-create flows still work (the `is_active` rename preserves the DB column).

https://claude.ai/code/session_01P9TubeCXQbxCmTdW98uYaa